### PR TITLE
sidestep Jest failing when converting to ESM

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
 'use strict';
 
-module.exports = require('constants');
+const c = require('constants');
+
+module.exports = c;


### PR DESCRIPTION
Over [here](https://github.com/facebook/jest/issues/9771) there's a bit of a kafuffle around the way that Jest is resolving modules.

When trying to import `ipfs-core` using ESM inside Jest tests, it breaks because Jest seems to get confused when `module.exports` and `require` are part of the same expression.  Breaking it up as proposed makes the problem go away.